### PR TITLE
Retire button added to the merchant dashboard

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,8 +1,8 @@
 class ProductsController < ApplicationController
 
-  before_action :find_product, only: [:show, :edit, :update, :destroy]
+  before_action :find_product, only: [:show, :edit, :update, :destroy, :retire]
   # before_action :only_see_own_page, only: [:create, :edit, :update, :destroy]
-  before_action :require_ownership, only: [:edit, :update, :destroy]
+  before_action :require_ownership, only: [:edit, :update, :destroy, :retire]
 
 
   def index
@@ -86,6 +86,16 @@ class ProductsController < ApplicationController
     end
   end
 
+  def retire
+    @product.in_stock = 0
+    if @product.save
+      flash[:success] = "Successfully retired!"
+    else
+      flash[:error] = "Could not be retired"
+    end
+    redirect_to user_path(@current_user.id)
+  end
+
   private
   def product_params
     params.require(:product).permit(:name, :description, :category, :price, :in_stock, category_ids:[])
@@ -114,4 +124,5 @@ class ProductsController < ApplicationController
     end
     return "/uploads/#{uploaded_file.original_filename}"
   end
+
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -17,6 +17,7 @@
                 <td><%= product.in_stock %></td>
                 <td>
                     <%= link_to "Edit", edit_product_path(product), class: "btn btn-primary" %>
+                    <%= link_to "Retire", retire_path(product), class: "btn btn-primary", method: :post %>
                     <%= link_to "Delete", product_path(product), class: "btn btn-danger", method: "delete", data: { confirm: "Are you sure?" } %>
                 </td>
             </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
     resources :order_items, only: [:create]
   end
 
+  post "/products/:id/retire", to: "products#retire", as: "retire"
+
   get 'products/:id/reviews/new', to: 'reviews#new'
   post 'products/:id/reviews', to: 'reviews#create'
 


### PR DESCRIPTION
Now merchant can retire a product by pressing retire button on the dashboard, so in stock amount set to 0.
The product will disappear from a products list.